### PR TITLE
Add pictures for CECH-3000

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ Currently, **Raspberry Pi Pico (RP2040)** and **RP2040-Zero** are supported.
 <details>
   <summary> <b>3000</b> </summary>
 <p>
-<img src="https://github.com/user-attachments/assets/6787886e-58a6-4fe9-877c-7ce4efbf8af7" />
+<img width="1032" height="910" alt="554644994-b3ade08e-a521-4a61-87c8-1783419128bf" src="https://github.com/user-attachments/assets/74037604-95fe-4dec-8e1e-f0a5025e8a7e" />
+
+<img width="664" height="664" alt="554644993-ef1747d8-505d-4ab8-98fb-f77911ead2d4" src="https://github.com/user-attachments/assets/43d21dfd-ed81-47da-8c68-c7869be4abf0" />
+
+<img width="501" height="501" alt="554644995-ec252dea-e781-46e6-9b51-c417dda285dd" src="https://github.com/user-attachments/assets/da1cc758-e856-4a02-9eac-8e6e60db38f1" />
 </p>
 </details>
 


### PR DESCRIPTION
Add solder point images for 3000.
<img width="664" height="664" alt="554644993-ef1747d8-505d-4ab8-98fb-f77911ead2d4" src="https://github.com/user-attachments/assets/79b0d24a-0210-42e0-80ea-f301610b61ac" />
<img width="1032" height="910" alt="554644994-b3ade08e-a521-4a61-87c8-1783419128bf" src="https://github.com/user-attachments/assets/43a1a9c8-9505-4975-9bfd-8c93d5ec6fe3" />
<img width="501" height="501" alt="554644995-ec252dea-e781-46e6-9b51-c417dda285dd" src="https://github.com/user-attachments/assets/8552f2d4-029f-4001-8046-f87d45cbac9f" />
